### PR TITLE
pglogical_drop_node should release the LWLock it acquires

### DIFF
--- a/contrib/pglogical/pglogical_functions.c
+++ b/contrib/pglogical/pglogical_functions.c
@@ -216,14 +216,14 @@ pglogical_drop_node(PG_FUNCTION_ARGS)
 					strncmp(NameStr(slot->data.name), "pgl_", 4) != 0)
 				{
 					SpinLockRelease(&slot->mutex);
-					LWLockAcquire(ReplicationSlotControlLock, LW_SHARED);
+					LWLockRelease(ReplicationSlotControlLock);
 					continue;
 				}
 
 				if (slot->active_pid != 0)
 				{
 					SpinLockRelease(&slot->mutex);
-					LWLockAcquire(ReplicationSlotControlLock, LW_SHARED);
+					LWLockRelease(ReplicationSlotControlLock);
 					ereport(ERROR,
 							(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 							 errmsg("cannot drop node \"%s\" because replication slot \"%s\" on the node is still active",
@@ -231,7 +231,7 @@ pglogical_drop_node(PG_FUNCTION_ARGS)
 							 errhint("drop the subscriptions first")));
 				}
 				SpinLockRelease(&slot->mutex);
-				LWLockAcquire(ReplicationSlotControlLock, LW_SHARED);
+				LWLockRelease(ReplicationSlotControlLock);
 
 				ReplicationSlotDrop(NameStr(slot->data.name));
 			}


### PR DESCRIPTION
Failing to release these locks causes subsequent acquires for exclusive access to fail.

This can be reproduced with the following steps:
- Create a provider node
- Drop the node
- Recreate the node
- Create a subscription to that node

That subscription will never be able to complete the sync because it will be blocked while trying to acquire the ReplicationSlotControlLock in exclusive mode while creating the replication slot on the provider

cc @ringerc 

I'll make this change locally and rebuild my rpms to verify the fix.
